### PR TITLE
User admin form now will have 'enabled' checked by default

### DIFF
--- a/src/Application/Sonata/UserBundle/Admin/Entity/UserAdmin.php
+++ b/src/Application/Sonata/UserBundle/Admin/Entity/UserAdmin.php
@@ -81,7 +81,7 @@ class UserAdmin extends BaseUserAdmin
                 ))
                 ->add('locked', null, array('required' => false))
                 ->add('expired', null, array('required' => false))
-                ->add('enabled', null, array('required' => false))
+                ->add('enabled', null, array('required' => false), 'attr' => array('checked' => 'yes'))
                 ->add('credentialsExpired', null, array('required' => false))
                 ->end();
         }


### PR DESCRIPTION
The enabled field needs to be true for a user to be allowed to sign in. Previously, the form field defaulted to unchecked (false), but this is contrary to most use cases (in common use cases, new accounts would be enabled immediately).
