### PR TITLE
set package name and description for packagist.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "symfony/framework-standard-edition",
-    "description": "The \"Symfony Standard Edition\" distribution",
+    "name": "jmather/symfony-sonata-distribution",
+    "description": "The \"Symfony Sonata Edition\" distribution",
     "autoload": {
         "psr-0": { "": "src/" }
     },


### PR DESCRIPTION
I think this should be a proper symfony distribution, therefor it should be published on packagist.org so it can be installed like this:

```
composer create-project jmather/symfony-sonata-distribution demoapp
```

(https://getcomposer.org/doc/03-cli.md#create-project)

You can log in to packagist with your githun account. The instructions to hook the git repository up to the packagist site are easy as well.
